### PR TITLE
fixes most math formulas created used quicklatex.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -7,6 +7,7 @@ span#closed_text > img[src^="https://www.gstatic.com/images/branding/googlelogo"
 span[data-href^="https://www.hcaptcha.com/"] > #icon
 ::-webkit-calendar-picker-indicator
 img.Wirisformula
+img[title="Rendered by QuickLaTeX.com"]
 
 CSS
 .vimvixen-hint {


### PR DESCRIPTION
fixes most math formulas created used quicklatex.com

for example https://www.basicairdata.eu/knowledge-center/design/angle-of-attack-vane/

Their images already play nice with a transparent background that works fine on most backgrounds. But the inverting breaks it on dark mode.

I'm not associated with them, just find their images often enough all over the web.